### PR TITLE
Pull changes from main

### DIFF
--- a/stdlib/head-layer/include/cldi/head/setup/icxx/stat.hpp
+++ b/stdlib/head-layer/include/cldi/head/setup/icxx/stat.hpp
@@ -48,8 +48,41 @@ namespace cldi
 
 	constexpr STAT EINCOMPATIBLE_TYPE = ::CLDI_EINCOMPATIBLE_TYPE;
 
+	using CSTDLIB_ERRCONTEXT = ::CLDI_CSTDLIB_ERRCONTEXT;
+
+	constexpr CSTDLIB_ERRCONTEXT CSTDEC_PRINTF = ::CLDI_CSTDEC_PRINTF;
+	constexpr CSTDLIB_ERRCONTEXT CSTDEC_VPRINTF = ::CLDI_CSTDEC_VPRINTF;
+	constexpr CSTDLIB_ERRCONTEXT CSTDEC_FPRINTF = ::CLDI_CSTDEC_FPRINTF;
+	constexpr CSTDLIB_ERRCONTEXT CSTDEC_VFPRINTF = ::CLDI_CSTDEC_VFPRINTF;
+	constexpr CSTDLIB_ERRCONTEXT CSTDEC_SPRINTF = ::CLDI_CSTDEC_SPRINTF;
+	constexpr CSTDLIB_ERRCONTEXT CSTDEC_SNPRINTF = ::CLDI_CSTDEC_SNPRINTF;
+	constexpr CSTDLIB_ERRCONTEXT CSTDEC_VSPRINTF = ::CLDI_CSTDEC_VSPRINTF;
+	constexpr CSTDLIB_ERRCONTEXT CSTDEC_VSNPRINTF = ::CLDI_CSTDEC_VSNPRINTF;
+	constexpr CSTDLIB_ERRCONTEXT CSTDEC_VASPRINTF = ::CLDI_CSTDEC_VASPRINTF;
+	constexpr CSTDLIB_ERRCONTEXT CSTDEC_ASPRINTF = ::CLDI_CSTDEC_ASPRINTF;
+	constexpr CSTDLIB_ERRCONTEXT CSTDEC_VDPRINTF = ::CLDI_CSTDEC_VDPRINTF;
+	constexpr CSTDLIB_ERRCONTEXT CSTDEC_DPRINTF = ::CLDI_CSTDEC_DPRINTF;
+
 	inline STAT &ERRNO = CLDI_ERRNO;
 
+	/* Function for converting C++ standard library errors into CLDISTAT error
+	.  codes. */
+	template <typename _E>
+	CLDISTAT ConvCppStdlibError(CSTDLIB_ERRCONTEXT error_context, _E error)
+	{
+		static_assert(
+			std::is_base_of<std::exception, _E>::value,
+			"cldi-head: cldi::ConvCppStdlibError() can only be used with type argument of std::exception or child classes of such."
+		);
+		switch (error_context)
+		{
+			default:
+				return EUNKNOWN;
+		}
+	}
+
+	inline CLDISTAT    (&ConvCStdlibError)(CSTDLIB_ERRCONTEXT, int) = ::cldiConvCStdlibError;
+	inline CLDISTAT    (&ConvCStdlibErrno)(CSTDLIB_ERRCONTEXT) = ::cldiConvCStdlibErrno;
 	inline const char* (&GetErrorName)(STAT) = ::cldiGetErrorName;
 	inline const char* (&GetErrnoName)() = ::cldiGetErrnoName;
 	inline bool        (&StatWarning)(STAT) = ::cldiStatWarning;

--- a/stdlib/head-layer/include/cldi/head/setup/icxx/types.hpp
+++ b/stdlib/head-layer/include/cldi/head/setup/icxx/types.hpp
@@ -18,8 +18,17 @@ namespace cldi
 
 	using floatmax_t    = ::cldifpm_t;
 	using fpm_t         = ::cldifpm_t;
+	constexpr fpm_t FPM_MANT_DIG = CLDIFPM_MANT_DIG;
+	constexpr fpm_t FPM_DIG = CLDIFPM_DIG;
+	constexpr fpm_t FPM_MIN_EXP = CLDIFPM_MIN_EXP;
+	constexpr fpm_t FPM_MIN_10_EXP = CLDIFPM_MIN_10_EXP;
+	constexpr fpm_t FPM_MAX_EXP = CLDIFPM_MAX_EXP;
+	constexpr fpm_t FPM_MAX_10_EXP = CLDIFPM_MAX_10_EXP;
+	constexpr fpm_t FPM_MAX = CLDIFPM_MAX;
+	constexpr fpm_t FPM_EPSILON = CLDIFPM_EPSILON;
+	constexpr fpm_t FPM_MIN = CLDIFPM_MIN;
 
-	using TYPE_TEMPL    = ::CLDI_TYPE_TEMPL;
+	using TYPE_TEMPL= ::CLDI_TYPE_TEMPL;
 	using TYPE_TEMPLATE = ::CLDI_TYPE_TEMPL;
 	constexpr TYPE_TEMPL TYPE_TEMPL_NULL = ::CLDI_NULL_TYPE;
 	constexpr TYPE_TEMPL TYPE_TEMPL_INTEGER = ::CLDI_INTEGER_TYPE;

--- a/stdlib/head-layer/include/cldi/head/setup/includes.h
+++ b/stdlib/head-layer/include/cldi/head/setup/includes.h
@@ -14,6 +14,7 @@
 #	include <stddef.h>
 #	include <stdlib.h>
 #   include <float.h>
+#	include <limits.h>
 #	include <string.h>
 #	if CLDI_INCLUDE_MATH == true
 #		include <math.h>
@@ -25,6 +26,7 @@
 #	include <cstddef>
 #	include <cstdlib>
 #	include <cfloat>
+#   include <climits>
 #	include <cstring>
 #   include <typeinfo>
 #   include <type_traits>

--- a/stdlib/head-layer/include/cldi/head/setup/stat.h
+++ b/stdlib/head-layer/include/cldi/head/setup/stat.h
@@ -46,11 +46,32 @@ typedef enum _CLDISTAT
 
 	CLDI_EINCOMPATIBLE_TYPE,
 } CLDISTAT;
+/* C Standard Library Error contexts */
+typedef enum _CLDICSTDEC
+{
+	CLDI_CSTDEC_PRINTF,
+	CLDI_CSTDEC_VPRINTF   = CLDI_CSTDEC_PRINTF,
+	CLDI_CSTDEC_FPRINTF   = CLDI_CSTDEC_PRINTF,
+	CLDI_CSTDEC_VFPRINTF  = CLDI_CSTDEC_PRINTF,
+	CLDI_CSTDEC_SPRINTF   = CLDI_CSTDEC_PRINTF,
+	CLDI_CSTDEC_SNPRINTF  = CLDI_CSTDEC_PRINTF,
+	CLDI_CSTDEC_VSPRINTF  = CLDI_CSTDEC_PRINTF,
+	CLDI_CSTDEC_VSNPRINTF = CLDI_CSTDEC_PRINTF,
+	CLDI_CSTDEC_VASPRINTF = CLDI_CSTDEC_PRINTF,
+	CLDI_CSTDEC_ASPRINTF  = CLDI_CSTDEC_PRINTF,
+	CLDI_CSTDEC_VDPRINTF  = CLDI_CSTDEC_PRINTF,
+	CLDI_CSTDEC_DPRINTF   = CLDI_CSTDEC_PRINTF,
+} CLDI_CSTDLIB_ERRCONTEXT;
 
 /* This is a global variable for passing errors while keeping return type. */
 extern CLDISTAT CLDI_ERRNO;
 
 /* Methods associated with CLDISTAT values: */
+
+// Convert a C Standard library error into a CLDISTAT error code.
+CLDISTAT cldiConvCStdlibError(CLDI_CSTDLIB_ERRCONTEXT error_context, int error);
+// - Convert from C Standard Library "errno" flag
+CLDISTAT cldiConvCStdlibErrno(CLDI_CSTDLIB_ERRCONTEXT error_context);
 
 /* Get the descriptor string associated with an error code. */
 const char* cldiGetErrorName(CLDISTAT e);

--- a/stdlib/head-layer/include/cldi/head/setup/types.h
+++ b/stdlib/head-layer/include/cldi/head/setup/types.h
@@ -26,10 +26,28 @@ cldipid_t cldiGetCurrentPID();
 #   define CLDI_LDBL_ENABLED true
 typedef long double cldifloatmax_t;
 typedef long double cldifpm_t;
+#	define CLDIFPM_MANT_DIG   LDBL_MANT_DIG
+#	define CLDIFPM_DIG        LDBL_DIG
+#	define CLDIFPM_MIN_EXP    LDBL_MIN_EXP
+#	define CLDIFPM_MIN_10_EXP LDBL_MIN_10_EXP
+#	define CLDIFPM_MAX_EXP    LDBL_MAX_EXP
+#	define CLDIFPM_MAX_10_EXP LDBL_MAX_10_EXP
+#	define CLDIFPM_MAX        LDBL_MAX
+#	define CLDIFPM_EPSILON    LDBL_EPSILON
+#	define CLDIFPM_MIN        LDBL_MIN
 #else
 #	define CLDI_LDBL_ENABLED false
 typedef      double cldifloatmax_t;
 typedef      double cldifpm_t;
+#	define CLDIFPM_MANT_DIG   DBL_MANT_DIG
+#	define CLDIFPM_DIG        DBL_DIG
+#	define CLDIFPM_MIN_EXP    DBL_MIN_EXP
+#	define CLDIFPM_MIN_10_EXP DBL_MIN_10_EXP
+#	define CLDIFPM_MAX_EXP    DBL_MAX_EXP
+#	define CLDIFPM_MAX_10_EXP DBL_MAX_10_EXP
+#	define CLDIFPM_MAX        DBL_MAX
+#	define CLDIFPM_EPSILON    DBL_EPSILON
+#	define CLDIFPM_MIN        DBL_MIN
 #endif
 
 
@@ -52,7 +70,6 @@ typedef struct _CLDITYPEINFO
 {
 	size_t          size;
 	CLDI_TYPE_TEMPL templ;
-
 } clditypeinfo_t;
 
 /* Predefined templates for different types represented as clditypeinfo_t objects. */


### PR DESCRIPTION
Add <climits>/<limits.h> to setup/includes.h, update setup/types.h and setup/icxx/types.hpp with macro presets for cldifpm_t constants, and update setup/stat.h and setup/icxx/stat.hpp with a new enum and starting set of values for interpretting C/C++ Standard Library errors in different function contexts.