### PR TITLE
Pull changes from main (main->devtest-iter)

### DIFF
--- a/stdlib/head-layer/include/cldi/head/setup.h
+++ b/stdlib/head-layer/include/cldi/head/setup.h
@@ -8,10 +8,13 @@
 
 /* CLDI Version */
 #define CLDI_VERSION 250000000UL
+const unsigned long CLDI_LIB_VER  = CLDI_VERSION;
+const unsigned long CLDI_HEAD_VER = CLDI_VERSION;
 #if CLDI_C_ONLY == false
 namespace cldi
 {
-	constexpr unsigned long VERSION = CLDI_VERSION;
+	constexpr unsigned long VERSION      = CLDI_VERSION;
+	constexpr unsigned long HEAD_VERSION = CLDI_VERSION;
 }
 #endif
 

--- a/stdlib/head-layer/include/cldi/head/setup/icxx/types.hpp
+++ b/stdlib/head-layer/include/cldi/head/setup/icxx/types.hpp
@@ -13,8 +13,12 @@
 namespace cldi
 {
 	using pid_t = ::cldipid_t;
+	using gid_t = ::cldigid_t;
+	using oid_t = ::cldioid_t;
 
-	inline pid_t (&GetCurrentPID)() = cldiGetCurrentPID;
+	inline pid_t (&GetCurrentPID)() = ::cldiGetCurrentPID;
+	inline gid_t (&GetCurrentGID)() = ::cldiGetCurrentGID;
+	inline oid_t (&GetCurrentOID)() = ::cldiGetCurrentOID;
 
 	using floatmax_t    = ::cldifpm_t;
 	using fpm_t         = ::cldifpm_t;

--- a/stdlib/head-layer/include/cldi/head/setup/stat.h
+++ b/stdlib/head-layer/include/cldi/head/setup/stat.h
@@ -162,6 +162,19 @@ extern cldiexc_t CLDI_ERROR;
 	CLDI_ERROR.ec=CLDI_SUCCESS;
 /* This macro is used for error catch statements. */
 #define CLDI_CATCH if(CLDI_STAT_NOTPERMISSIBLE(CLDI_ERROR.ec))
+#if defined(__cldic)
+#	define CLDITHROWS   throws()
+#	define CLDITHROWEX  throws
+#	define CLDINOEXCEPT noexcept
+#elif CLDI_C_ONLY == false
+#	define CLDITHROWS       noexcept(false)
+#	define CLDITHROWEX(...) noexcept(false)
+#	define CLDINOEXCEPT     noexcept
+#else
+#	define CLDITHROWS
+#	define CLDITHROWEX(...)
+#	define CLDINOEXCEPT
+#endif
 
 /* Methods associated with CLDISTAT values: */
 

--- a/stdlib/head-layer/include/cldi/head/setup/types.h
+++ b/stdlib/head-layer/include/cldi/head/setup/types.h
@@ -4,11 +4,12 @@
 
 #include "includes.h"
 
-
-
 #ifdef __cplusplus
 extern "C" {
 #endif
+
+
+
 /* Process ID and Group ID type */
 #if CLDI_PLATFORM_UNIXLIKE == true
 typedef pid_t cldipid_t;


### PR DESCRIPTION
Added a global variable ('CLDI_LIB_VER') for cldi library version, and cldi-head ('CLDI_HEAD_VER') version, so that all separate CLDI libraries will have remnants of their own version embedded after compilation (https://github.com/jointednonprescribed/cldi/commit/429f49f4b46623f2e807beb3f575973792c86f6d).
Update head/setup/types.h and head/setup/icxx/types.hpp with types 'cldigid_t' and 'cldioid_t', to provide support for group ownership and identification for group participancy of owners on the system and/or multi-threaded runtime environment (https://github.com/jointednonprescribed/cldi/commit/e26dc8579697eac9813aa099f54edb97ef2a2650).
Update head/setup/stat.h with 'CLDINOEXCEPT', CLDITHOWS, and CLDITHROWEX(...) macros for error handling (https://github.com/jointednonprescribed/cldi/commit/eac42d6b39672640535fd23a5616e864929e1ed1).
main->devtest-iter