### PR TITLE
Pull changes from devtest-memory (devtest-memory->devtest-iter)

### DIFF
--- a/stdlib/head-layer/include/cldi/head/icxx/memory.hpp
+++ b/stdlib/head-layer/include/cldi/head/icxx/memory.hpp
@@ -24,21 +24,40 @@ namespace cldi
 	constexpr HEAPFLAG DEFAULT_SYSHEAP = ::CLDI_DEFAULT_SYSHEAP;
 	constexpr HEAPFLAG DEFAULT_ENVHEAP = ::CLDI_DEFAULT_ENVHEAP;
 
+	inline int (&ConvToSysHeapPerms)(int) = ::cldiConvToSysHeapPerms;
+	inline int (&ConvToSysHeapFlags)(int) = ::cldiConvToSysHeapFlags;
+
 	/* Alias for CLDIMBLKFLAG enum type */
-	using MBLKPERM      = CLDIMBLKFLAG;
+	using MBLK_FLAG = CLDIMBLKFLAG;
 	/* Enum values from _CLDIMBLKPERMS: */
-	constexpr MBLKPERM MBLK_OREAD = ::CLDI_MBLK_OREAD;
-	constexpr MBLKPERM MBLK_OWRTE = ::CLDI_MBLK_OWRTE;
-	constexpr MBLKPERM MBLK_OEXEC = ::CLDI_MBLK_OEXEC;
-	constexpr MBLKPERM MBLK_GREAD = ::CLDI_MBLK_GREAD;
-	constexpr MBLKPERM MBLK_GWRTE = ::CLDI_MBLK_GWRTE;
-	constexpr MBLKPERM MBLK_GEXEC = ::CLDI_MBLK_GEXEC;
-	constexpr MBLKPERM MBLK_PREAD = ::CLDI_MBLK_PREAD;
-	constexpr MBLKPERM MBLK_PWRTE = ::CLDI_MBLK_PWRTE;
-	constexpr MBLKPERM MBLK_PEXEC = ::CLDI_MBLK_PEXEC;
-	constexpr MBLKPERM MBLK_READ  = ::CLDI_MBLK_READ;
-	constexpr MBLKPERM MBLK_WRITE = ::CLDI_MBLK_WRITE;
-	constexpr MBLKPERM MBLK_EXEC  = ::CLDI_MBLK_EXEC;
+	condtexpr MBLK_FLAG MBLK_OREAD = ::CLDI_MBLK_OREAD;
+	condtexpr MBLK_FLAG MBLK_OWRTE = ::CLDI_MBLK_OWRTE;
+	condtexpr MBLK_FLAG MBLK_OEXEC = ::CLDI_MBLK_OEXEC;
+	condtexpr MBLK_FLAG MBLK_GREAD = ::CLDI_MBLK_GREAD;
+	condtexpr MBLK_FLAG MBLK_GWRTE = ::CLDI_MBLK_GWRTE;
+	condtexpr MBLK_FLAG MBLK_GEXEC = ::CLDI_MBLK_GEXEC;
+	condtexpr MBLK_FLAG MBLK_PREAD = ::CLDI_MBLK_PREAD;
+	condtexpr MBLK_FLAG MBLK_PWRTE = ::CLDI_MBLK_PWRTE;
+	condtexpr MBLK_FLAG MBLK_PEXEC = ::CLDI_MBLK_PEXEC;
+	condtexpr MBLK_FLAG MBLK_NO_AUTH = ::CLDI_MBLK_NO_AUTH;
+	condtexpr MBLK_FLAG MBLK_PAUTH = ::CLDI_MBLK_PAUTH;
+	condtexpr MBLK_FLAG MBLK_GAUTH = ::CLDI_MBLK_GAUTH;
+	condtexpr MBLK_FLAG MBLK_OAUTH = ::CLDI_MBLK_OAUTH;
+	condtexpr MBLK_FLAG MBLK_ACTIVEOWNER = ::CLDI_MBLK_ACTIVEOWNER;
+	/* Defaults */
+	contexpr MBLK_FLAG MBLK_DEFAULT_AUTH  = ::CLDI_DEFAULT_MBLK_AUTH;
+	contexpr MBLK_FLAG MBLK_DEFAULT_PERMS = ::CLDI_DEFAULT_MBLK_PERMS;
+	contexpr MBLK_FLAG MBLK_PRIVATE_PERMS = ::CLDI_PRIVATE_MBLK_PERMS;
+	/* Aliases */
+	contexpr MBLK_FLAG MBLK_READ          = ::CLDI_MBLK_READ;
+	contexpr MBLK_FLAG MBLK_WRITE         = ::CLDI_MBLK_WRITE;
+	contexpr MBLK_FLAG MBLK_EXEC          = ::CLDI_MBLK_EXEC;
+	contexpr MBLK_FLAG MBLK_OWNER_PERMS   = ::CLDI_MBLK_OWNER_PERMS;
+	contexpr MBLK_FLAG MBLK_GROUP_PERMS   = ::CLDI_MBLK_GROUP_PERMS;
+	contexpr MBLK_FLAG MBLK_PUBLIC_PERMS  = ::CLDI_MBLK_PUBLIC_PERMS;
+
+	inline int (&ConvToSysMemPerms)(int) = ::cldiConvToSysMemPerms;
+	inline int (&ConvToSysMemFlags)(int) = ::cldiConvToSysMemFlags;
 
 	/* Alias for cldimblkstat_t enum type */
 	using mblkstat_t    = ::cldimblkstat_t;
@@ -55,6 +74,9 @@ namespace cldi
 	using heapheader_t  = ::CLDI_HEAP_HEADER;
 	/* Alias for cldisysheap_t (system heap reference) */
 	using sysheap_t     = ::cldisysheap_t;
+	// - Predefined values for sysheap_t
+	constexpr sysheap_t SYSHEAP_NULL = CLDISYSHEAP_NULL;
+	constexpr sysheap_t SYSHEAP_CURRENT = CLDISYSHEAP_CURRENT;
 	/* Alias for cldimblkid_t (memory block ID) */
 	using mblkid_t      = ::cldimblkid_t;
 
@@ -81,23 +103,29 @@ namespace cldi
 
 		heap_t();
 		heap_t(size_t heapsize, int flags);
-		heap_t(size_t bufsize, size_t heapsize, int flags);
-		heap_t(sysheap_t sysheap);
+		heap_t(size_t heapsize, size_t bufsize=DEFAULT_MBLK_BUFSIZE, int flags=MBLK_);
+		heap_t(sysheap_t sysheap, size_t bufsize=DEFAULT_MBLK_BUFSIZE);
 		heap_t(const _gheap_t &conv);
 		heap_t(const heap_t &rhv);
 		~heap_t();
 
 		STAT Drop();
 
-		static heap_t MakeHeapFromCurrent();
-		STAT MakeCurrentHeap();
-		STAT SetToCurrentHeap();
+		operator _gheap_t() const;
 
-		size_t GetTotalHeapSize() const;
-		size_t GetHeapSize() const;
-		size_t MemoryUsage() const;
-		double MemoryUsagePercent() const;
-		size_t MemoryRemaining() const;
+		static heap_t MakeHeapFromCurrent();
+		STAT SetAsCurrentHeap();
+		STAT AdoptCurrentHeap();
+
+		size_t          TotalSize() const;
+		size_t          Size() const;
+		size_t          MemoryUsage() const;
+		double          MemoryUsagePercent() const;
+		size_t          MemoryRemaining() const;
+		const char*     GetName() const;
+		memref<wchar_t> GetNameW();
+		STAT            SetName(const char *name);
+		STAT            SetName(const wchar_t *name);
 
 		template <typename _T>
 		mblkid_t   NewBlock(int flags)
@@ -137,7 +165,9 @@ namespace cldi
 		const void *const GetBlockConstAddr(mblkid_t blkid)        const;
 		STAT              GetBlockStatus(mblkid_t blkid)           const;
 		int               GetBlockPerms(mblkid_t blkid)            const;
-		cldipid_t         GetBlockOwner(mblkid_t blkid)            const;
+		oid_t             GetBlockOwner(mblkid_t blkid)            const;
+		pid_t             GetBlockOwnerThread(mblkid_t blkid)            const;
+		gid_t             GetBlockOwnerGroup(mblkid_t blkid)            const;
 		int               GetBlockRefCount(mblkid_t blkid)         const;
 		size_t            GetBlockSize(mblkid_t blkid)             const;
 		size_t            GetBlockCapacity(mblkid_t blkid)         const;
@@ -164,11 +194,6 @@ namespace cldi
 		bool IsSysheap() const;
 		bool IsEnvHeap() const;
 		bool IsLowFrag() const;
-
-		const char*     GetName() const;
-		memref<wchar_t> GetNameW();
-		STAT            SetName(const char *name);
-		STAT            SetName(const wchar_t *name);
 
 		template <typename _T>
 		memref<_T> CallAllocator(mblkallocator<_T> allocator)
@@ -204,20 +229,20 @@ namespace cldi
 
 	public:
 
-		bool MatchTypeInfo(const _gtypeinfo_t &info)
+		TYPE_COMPAT MatchTypeInfo(const _gtypeinfo_t &info)
 		{
 			return info.size == sizeof(_T) && info.templ == typeinfo_t<_T>::TEMPLATE;
 		}
-		bool MatchBlockType(const heap_t &heap, memblkid_t blkid)
+		TYPE_COMPAT MatchBlockType(const heap_t &heap, memblkid_t blkid)
 		{
 			_gtypeinfo_t info = heap->GetBlockType(blkid);
 			return info.size == sizeof(_T) && info.templ == typeinfo_t<_T>::TEMPLATE;
 		}
-		bool MatchBlockType(mblkid_t blkid)
+		TYPE_COMPAT MatchBlockType(mblkid_t blkid)
 		{
 			return MatchBlockType(*(this->heap), blkid);
 		}
-		bool MatchBlockType(const memref<_T> &ref)
+		TYPE_COMPAT MatchBlockType(const memref<_T> &ref)
 		{
 			return MatchBlockType(ref.id, ref.heap);
 		}
@@ -252,7 +277,7 @@ namespace cldi
 		{
 			errno = SUCCESS;
 
-			if (!MatchTypeInfo(rhv.objtype)) {
+			if (MatchTypeInfo(rhv.objtype) != TYPE_COMPAT_FULL) {
 				errno = EINCOMPATIBLE_TYPE;
 				return EINCOMPATIBLE_TYPE;
 			}

--- a/stdlib/head-layer/include/cldi/head/memory.h
+++ b/stdlib/head-layer/include/cldi/head/memory.h
@@ -4,11 +4,11 @@
 
 #include "functypes.h"
 
-
-
 #ifdef __cplusplus
 extern "C" {
 #endif
+
+
 
 /* This enum contains bit settings for flags that modify heap initialization and
 .  maintenance. */
@@ -107,16 +107,16 @@ typedef void (*cldimblkdestr_t)(cldimemref*);
 .  specify "current heap"). */
 #if CLDI_PLATFORM_UNIXLIKE == true
 typedef int cldisysheap_t;
-#define CLDISYSHEAP_NULL    (-1)
-#define CLDISYSHEAP_CURRENT 0
+#	define CLDISYSHEAP_NULL    (-1)
+#	define CLDISYSHEAP_CURRENT 0
 #elif CLDI_PLATFORM == CLDI_WINDOWS
 typedef HANDLE cldisysheap_t;
-#define CLDISYSHEAP_NULL    NULL
-#define CLDISYSHEAP_CURRENT (GetCurrentHeap())
+#	define CLDISYSHEAP_NULL    NULL
+#	define CLDISYSHEAP_CURRENT (GetCurrentHeap())
 #else
 typedef int cldisysheap_t;
-#define CLDISYSHEAP_NULL    (-1)
-#define CLDISYSHEAP_CURRENT 0
+#	define CLDISYSHEAP_NULL    (-1)
+#	define CLDISYSHEAP_CURRENT 0
 #endif
 
 /* Memory Block Header type; this type is placed in the offset of an allocated
@@ -135,7 +135,7 @@ typedef struct _CLDIMBLKH
 	// The current status of the block.
 	cldimblkstat_t status;
 	// The owner thread of the block.
-	cldipid_t      owner;
+	cldioid_t      owner;
 } CLDI_MBLK_HEADER;
 
 /* Heap Header type; this type is placed in the offset of an allocated heap to
@@ -161,7 +161,7 @@ typedef struct _CLDIHEAPH
 	/* Heap permissions. */
 	int                perms;
 	/* The owner thread of the heap. */
-	cldipid_t          owner;
+	cldioid_t          owner;
 } CLDI_HEAP_HEADER;
 
 /* Memory Reference type */
@@ -172,7 +172,7 @@ struct _CLDIMEMREF
 	void           *ptr;
 	cldiheap_t     *heap;
 	cldimblkid_t    id;
-	cldipid_t       owner;
+	cldioid_t       owner;
 	bool active, activeid, shared;
 };
 
@@ -193,7 +193,7 @@ typedef struct _CLDIHEAP
 /* Methods associated with cldimemref objects: */
 
 /* Construct a cldimemref as blank (null). */
-CLDISTAT cldiInitMemref(cldimemref *self);
+CLDISTAT cldiInitMemref(cldimemref *self) CLDINOEXCEPT;
 /* Construct a cldimemref from an existing block using its ID. */
 CLDISTAT cldiInitMemrefExistingID(cldimemref *self, cldimblkid_t blkid);
 /* Construct a cldimemref with a copy of an existing block using its ID. */
@@ -219,7 +219,7 @@ CLDISTAT cldiInitMemrefNewBlockOnHeapEx(cldimemref *self, cldiheap_t *heap, cldi
 CLDISTAT cldiInitMemrefNewArrayOnHeap(cldimemref *self, cldiheap_t *heap, clditypeinfo_t block_type, size_t array_size, int flags);
 CLDISTAT cldiInitMemrefNewArrayOnHeapEx(cldimemref *self, cldiheap_t *heap, clditypeinfo_t block_type, size_t array_size, int flags, cldimblkdestr_t destructor);
 /* Make a new instance and pass it over the stack -- Corresponding to constructors. */
-cldimemref cldiMakeMemref();
+cldimemref cldiMakeMemref() CLDINOEXCEPT;
 cldimemref cldiMakeMemrefExistingID(cldimblkid_t blkid);
 cldimemref cldiMakeMemrefCopyID(cldimblkid_t blkid);
 cldimemref cldiMakeMemrefOnHeap(cldiheap_t *heap, cldimblkid_t blkid);
@@ -251,31 +251,43 @@ const void*           cldiMemrefGetConstAddress(const cldimemref *self);
 cldimblkid_t          cldiMemrefGetBlockID(const cldimemref *self);
 /* Get the cldimemref's block type info. */
 const clditypeinfo_t* cldiMemrefGetBlockType(const cldimemref *self);
-/* Get the owner of the cldimemref object's memory block (may not be the current
+/* Get the permissions and flags of the memory block. */
+int                   cldiMemrefGetBlockFlags(const cldimemref *self);
+/* Get the owner ID of the cldimemref object's memory block (may not be the current
 .  thread). */
-cldipid_t             cldiMemrefGetBlockOwner(const cldimemref *self);
-/* Get the owner of the cldimemref object itself. */
-cldipid_t             cldiMemrefGetOwner(const cldimemref *self);
+cldioid_t             cldiMemrefGetBlockOwner(const cldimemref *self);
+/* Get the owner of the cldimemref object's memory block's process ID (may not be
+.  the current thread). */
+cldipid_t             cldiMemrefGetBlockOwnerThread(const cldimemref *self);
+/* Get the owner of the cldimemref object's memory block's group ID (may not be
+.  the same as the current thread). */
+cldigid_t             cldiMemrefGetBlockOwnerGroup(const cldimemref *self);
+/* Get the owner ID of the cldimemref object itself. */
+cldioid_t             cldiMemrefGetOwner(const cldimemref *self);
+/* Get the owner of the cldimemref object's process ID. */
+cldipid_t             cldiMemrefGetOwnerThread(const cldimemref *self);
+/* Get the owner of the cldimemref object's group ID'. */
+cldigid_t             cldiMemrefGetOwnerGroup(const cldimemref *self);
 
 /* Check if the cldimemref is null. */
-bool                  cldiMemrefIsNull(const cldimemref *self);
+bool                  cldiMemrefIsNull(const cldimemref *self) CLDINOEXCEPT;
 /* Check if the cldimemref is non-null. */
-bool                  cldiMemrefIsNonNull(const cldimemref *self);
+bool                  cldiMemrefIsNonNull(const cldimemref *self) CLDINOEXCEPT;
 /* Check if the cldimemref is active. */
-bool                  cldiMemrefIsActive(const cldimemref *self);
+bool                  cldiMemrefIsActive(const cldimemref *self) CLDINOEXCEPT;
 /* Check if the cldimemref is inactive. */
-bool                  cldiMemrefIsInactive(const cldimemref *self);
+bool                  cldiMemrefIsInactive(const cldimemref *self) CLDINOEXCEPT;
 /* Check if the cldimemref is active by an ID, as opposed to a raw pointer. */
-bool                  cldiMemrefHasActiveID(const cldimemref *self);
+bool                  cldiMemrefHasActiveID(const cldimemref *self) CLDINOEXCEPT;
 /* Check if the cldimemref is not active by an ID, instead it is active by a raw
 .  pointer. */
-bool                  cldiMemrefHasRawPtr(const cldimemref *self);
+bool                  cldiMemrefHasRawPtr(const cldimemref *self) CLDINOEXCEPT;
 /* Check if the cldimemref is borrowing its reference. */
-bool                  cldiMemrefIsBorrowing(const cldimemref *self);
+bool                  cldiMemrefIsBorrowing(const cldimemref *self) CLDINOEXCEPT;
 /* Check if the cldimemref is non-null. */
-bool                  cldiMemrefIsBlockOwner(const cldimemref *self);
+bool                  cldiMemrefIsBlockOwner(const cldimemref *self) CLDINOEXCEPT;
 /* Check if the block is currently shared between multiple blocks. */
-bool                  cldiMemrefBlockIsShared(const cldimemref *self);
+bool                  cldiMemrefBlockIsShared(const cldimemref *self) CLDINOEXCEPT;
 
 
 /* Methods associated with heap objects: */
@@ -296,13 +308,13 @@ cldimemref  cldiHeapCallAllocator(cldiheap_t *heap, cldiallocator_t allocator);
 extern cldiheap_t *CLDI_CURRENT_HEAP;
 // Reservation for a heap to initialize after program start and link to
 // CLDI_CURRENT_HEAP until modified (or unless modified first).
-extern cldiheap_t  _CLDI_ENTRY_HEAP;
+extern cldiheap_t _CLDI_ENTRY_HEAP;
 
 cldiheap_t*    cldiGetCurrentHeap();
 CLDISTAT       cldiSetCurrentHeap(cldiheap_t *set_to);
 cldisysheap_t  cldiGetCurrentSysheap();
 
-CLDISTAT       cldiInitHeap(cldiheap_t *self);
+CLDISTAT       cldiInitHeap(cldiheap_t *self) CLDINOEXCEPT;
 CLDISTAT       cldiInitHeapCurrent(cldiheap_t *self);
 CLDISTAT       cldiInitHeapCurrentBuf(cldiheap_t *self, size_t bufsize);
 CLDISTAT       cldiInitEnvHeap(cldiheap_t *self, size_t heap_size, int flags);
@@ -310,14 +322,27 @@ CLDISTAT       cldiInitEnvHeapBuf(cldiheap_t *self, size_t heap_size, size_t buf
 CLDISTAT       cldiInitSysheap(cldiheap_t *self, cldisysheap_t sysheap);
 CLDISTAT       cldiInitSysheapBuf(cldiheap_t *self, cldisysheap_t sysheap, size_t bufsize);
 
-cldiheap_t*    cldiNewHeap(cldiheap_t *self);
-cldiheap_t*    cldiNewHeapCurrent(cldiheap_t *self);
-cldiheap_t*    cldiNewHeapCurrentBuf(cldiheap_t *self, size_t bufsize);
-cldiheap_t*    cldiNewEnvHeap(cldiheap_t *self, size_t heap_size, int flags);
-cldiheap_t*    cldiNewEnvHeapBuf(cldiheap_t *self, size_t heap_size, size_t bufsize, int flags);
-cldiheap_t*    cldiNewSysheap(cldiheap_t *self, cldisysheap_t sysheap);
-cldiheap_t*    cldiNewSysheapBuf(cldiheap_t *self, cldisysheap_t sysheap, size_t bufsize);
+cldiheap_t     cldiMakeHeap();
+cldiheap_t     cldiMakeHeapCurrent();
+cldiheap_t     cldiMakeHeapCurrentBuf(size_t bufsize);
+cldiheap_t     cldiMakeEnvHeap(size_t heap_size, int flags);
+cldiheap_t     cldiMakeEnvHeapBuf(size_t heap_size, size_t bufsize, int flags);
+cldiheap_t     cldiMakeSysheap(cldisysheap_t sysheap);
+cldiheap_t     cldiMakeSysheapBuf(cldisysheap_t sysheap, size_t bufsize);
 
+cldiheap_t*    cldiNewHeap();
+cldiheap_t*    cldiNewHeapCurrent();
+cldiheap_t*    cldiNewHeapCurrentBuf(size_t bufsize);
+cldiheap_t*    cldiNewEnvHeap(size_t heap_size, int flags);
+cldiheap_t*    cldiNewEnvHeapBuf(size_t heap_size, size_t bufsize, int flags);
+cldiheap_t*    cldiNewSysheap(cldisysheap_t sysheap);
+cldiheap_t*    cldiNewSysheapBuf(cldisysheap_t sysheap, size_t bufsize);
+
+size_t         cldiHeapGetTotalSize(const cldiheap_t *self);
+size_t         cldiHeapGetSize(const cldiheap_t *self);
+size_t         cldiHeapMemoryUsage(const cldiheap_t *self);
+double         cldiHeapMemoryUsagePercent(const cldiheap_t *self);
+size_t         cldiHeapMemoryRemaining(const cldiheap_t *self);
 const char*    cldiGetHeapName(const cldiheap_t *self);
 cldimemref     cldiGetHeapNameW(const cldiheap_t *self);
 CLDISTAT       cldiSetHeapName(cldiheap_t *self, const char *name);
@@ -331,46 +356,50 @@ CLDISTAT       cldiHeapBorrowBlock(const cldiheap_t *self, cldimblkid_t blk);
 CLDISTAT       cldiHeapClaimBlock(const cldiheap_t *self, cldimblkid_t blk);
 CLDISTAT       cldiHeapDropBlock(cldiheap_t *self, cldimblkid_t blk);
 
-void*          cldiHeapGetBlockAddr(const cldiheap_t *self, cldimblkid_t blk);
+void*          cldiHeapGetBlockAddr(const cldiheap_t *self, cldimblkid_t blk)
+	CLDITHROWEX(CLDI_ENOT_WRITABLE, CLDI_ENO_ACCESS);
 const void*    cldiHeapGetBlockConstAddr(const cldiheap_t *self, cldimblkid_t blk);
 cldimblkstat_t cldiHeapGetBlockStatus(const cldiheap_t *self, cldimblkid_t blk);
-int            cldiHeapGetBlockRefCount(const cldiheap_t *self, cldimblkid_t blkid);
+int            cldiHeapGetBlockRefCount(const cldiheap_t *self, cldimblkid_t blk);
 size_t         cldiHeapGetBlockSize(const cldiheap_t *self, cldimblkid_t blk);
-size_t         cldiHeapGetBlockCapacity(const cldiheap_t *self, cldimblkid_t blkid);
-
+size_t         cldiHeapGetBlockCapacity(const cldiheap_t *self, cldimblkid_t blk);
+cldioid_t      cldiHeapGetBlockOwner(const cldiheap_t *self, cldimblkid_t blk);
+pid_t          cldiHeapGetBlockOwnerThread(const cldiheap_t *self, cldimblkid_t blkid);
+gid_t          cldiHeapGetBlockOwnerGroup(const cldiheap_t *self, cldimblkid_t blkid);
 int            cldiHeapGetBlockPerms(const cldiheap_t *self, cldimblkid_t blk);
-CLDISTAT       cldiHeapSetBlockPerms(const cldiheap_t *self, cldimblkid_t blk, int perms);
-CLDISTAT       cldiHeapAddBlockPerms(const cldiheap_t *self, cldimblkid_t blk, int perms);
-CLDISTAT       cldiHeapRemoveBlockPerms(const cldiheap_t *self, cldimblkid_t blk, int perms);
-CLDISTAT       cldiHeapClearBlockPerms(const cldiheap_t *self, cldimblkid_t blk);
+CLDISTAT       cldiHeapSetBlockPerms(const cldiheap_t *self, cldimblkid_t blk, int perms)
+	CLDITHROWEX(CLDI_ENO_ACCESS);
+CLDISTAT       cldiHeapAddBlockPerms(const cldiheap_t *self, cldimblkid_t blk, int perms)
+	CLDITHROWEX(CLDI_ENO_ACCESS);
+CLDISTAT       cldiHeapRemoveBlockPerms(const cldiheap_t *self, cldimblkid_t blk, int perms)
+	CLDITHROWEX(CLDI_ENO_ACCESS);
+CLDISTAT       cldiHeapClearBlockPerms(const cldiheap_t *self, cldimblkid_t blk)
+	CLDITHROWEX(CLDI_ENO_ACCESS);
 
-bool           cldiBlockStatIs(cldimblkid_t blk, cldimblkstat_t check_stat);
-bool           cldiBlockStatOnHeapIs(const cldiheap_t *self, cldimblkid_t blk, cldimblkstat_t stat);
-bool           cldiHeapIsBlockActive(const cldiheap_t *self, cldimblkid_t blk);
-bool           cldiHeapIsBlockPending(const cldiheap_t *self, cldimblkid_t blk);
-bool           cldiHeapIsBlockHole(const cldiheap_t *self, cldimblkid_t blk);
-bool           cldiHeapIsBlockWritable(const cldiheap_t *self, cldimblkid_t blk);
-bool           cldiHeapIsBlockReadable(const cldiheap_t *self, cldimblkid_t blk);
-bool           cldiHeapIsBlockExecutable(const cldiheap_t *self, cldimblkid_t blk);
-bool           cldiHeapIsBlockWritableOnThread(const cldiheap_t *self, cldimblkid_t blk, cldipid_t thr);
-bool           cldiHeapIsBlockReadableOnThread(const cldiheap_t *self, cldimblkid_t blk, cldipid_t thr);
-bool           cldiHeapIsBlockExecutableOnThread(const cldiheap_t *self, cldimblkid_t blk, cldipid_t thr);
+bool           cldiBlockStatEq(cldimblkid_t blk, cldimblkstat_t check_stat) CLDINOEXCEPT;
+bool           cldiBlockStatOnHeapEq(const cldiheap_t *self, cldimblkid_t blk, cldimblkstat_t stat) CLDINOEXCEPT;
+bool           cldiHeapIsBlockActive(const cldiheap_t *self, cldimblkid_t blk) CLDINOEXCEPT;
+bool           cldiHeapIsBlockPending(const cldiheap_t *self, cldimblkid_t blk) CLDINOEXCEPT;
+bool           cldiHeapIsBlockHole(const cldiheap_t *self, cldimblkid_t blk) CLDINOEXCEPT;
+bool           cldiHeapIsBlockWritable(const cldiheap_t *self, cldimblkid_t blk) CLDINOEXCEPT;
+bool           cldiHeapIsBlockReadable(const cldiheap_t *self, cldimblkid_t blk) CLDINOEXCEPT;
+bool           cldiHeapIsBlockExecutable(const cldiheap_t *self, cldimblkid_t blk) CLDINOEXCEPT;
+bool           cldiHeapIsBlockWritableOnThread(const cldiheap_t *self, cldimblkid_t blk, cldipid_t thr) CLDINOEXCEPT;
+bool           cldiHeapIsBlockReadableOnThread(const cldiheap_t *self, cldimblkid_t blk, cldipid_t thr) CLDINOEXCEPT;
+bool           cldiHeapIsBlockExecutableOnThread(const cldiheap_t *self, cldimblkid_t blk, cldipid_t thr) CLDINOEXCEPT;
 
-bool           cldiHeapIsNull(const cldiheap_t *self);
-bool           cldiHeapIsActive(const cldiheap_t *self);
-bool           cldiIsSysheap(const cldiheap_t *self);
-bool           cldiIsEnvHeap(const cldiheap_t *self);
-bool           cldiIsLowFragHeap(const cldiheap_t *self);
+bool           cldiHeapIsNull(const cldiheap_t *self) CLDINOEXCEPT;
+bool           cldiHeapIsActive(const cldiheap_t *self) CLDINOEXCEPT;
+bool           cldiIsSysheap(const cldiheap_t *self) CLDINOEXCEPT;
+bool           cldiIsEnvHeap(const cldiheap_t *self) CLDINOEXCEPT;
+bool           cldiIsLowFragHeap(const cldiheap_t *self) CLDINOEXCEPT;
+
 
 
 #ifdef __cplusplus
 }
 #endif
-
-
 /* C++ bindings for this file: */
 #include "icxx/memory.hpp"
-
-
 
 #endif // _cldi_head__MEMORY_H

--- a/stdlib/head-layer/include/cldi/head/setup.h
+++ b/stdlib/head-layer/include/cldi/head/setup.h
@@ -8,10 +8,13 @@
 
 /* CLDI Version */
 #define CLDI_VERSION 250000000UL
+const unsigned long CLDI_LIB_VER  = CLDI_VERSION;
+const unsigned long CLDI_HEAD_VER = CLDI_VERSION;
 #if CLDI_C_ONLY == false
 namespace cldi
 {
-	constexpr unsigned long VERSION = CLDI_VERSION;
+	constexpr unsigned long VERSION      = CLDI_VERSION;
+	constexpr unsigned long HEAD_VERSION = CLDI_VERSION;
 }
 #endif
 

--- a/stdlib/head-layer/include/cldi/head/setup/icxx/stat.hpp
+++ b/stdlib/head-layer/include/cldi/head/setup/icxx/stat.hpp
@@ -75,6 +75,27 @@ namespace cldi
 	inline exc_t &ERROR = CLDI_ERROR;
 	inline STAT  &ERRNO = CLDI_ERRNO;
 
+	cldiexc_t   (&ErrEc)(CLDISTAT) = ::cldierrec;
+	cldiexc_t   (&Err)(CLDISTAT, const char*) = ::cldierr;
+	cldiexc_t   (&ErrN)(CLDISTAT, const char*, const char*) = ::cldinerr;
+	cldiexc_t   (&ErrF)(CLDISTAT , void*, const char*) = ::cldierrf;
+	cldiexc_t   (&ErrNF)(CLDISTAT, void*, const char*, const char*) = ::cldinerrf;
+	cldiexc_t*  (&ThrowEc)(CLDISTAT) = ::cldithrowec;
+	cldiexc_t*  (&ThrowD)(CLDISTAT, const char*) = ::cldithrowd;
+	cldiexc_t*  (&ThrowN)(CLDISTAT, const char*, const char*) = ::cldinthrow;
+	cldiexc_t*  (&ThrowF)(CLDISTAT, void*, const char*) = ::cldithrowf;
+	cldiexc_t*  (&ThrowNF)(CLDISTAT, void*, const char*, const char*) = ::cldinthrowf;
+	cldiexc_t*  (&Throw)(cldiexc_t*) = ::cldithrow;
+	CLDISTAT    (&ExcGetErrno)(cldiexc_t*) = ::cldiExcGetErrno;
+	void*       (&ExcGetFunction)(cldiexc_t*) = ::cldiExcGetFunction;
+	const char* (&ExcGetName)(cldiexc_t*) = ::cldiExcGetName;
+	const char* (&ExcGetDesc)(cldiexc_t*) = ::cldiExcGetDesc;
+	bool        (&ExcSpecifiesFunction)(cldiexc_t*) = ::cldiExcSpecifiesFunction;
+	bool        (&ExcIsWarning)(cldiexc_t*) = ::cldiExcIsWarning;
+	bool        (&ExcIsError)(cldiexc_t*) = ::cldiExcIsError;
+	bool        (&ExcIsSuccess)(cldiexc_t*) = ::cldiExcIsSuccess;
+	bool        (&ExcIsPermissible)(cldiexc_t*) = ::cldiExcIsPermissible;
+
 	/* Function for converting C++ standard library errors into CLDISTAT error
 	.  codes. */
 	template <typename _E>

--- a/stdlib/head-layer/include/cldi/head/setup/icxx/stat.hpp
+++ b/stdlib/head-layer/include/cldi/head/setup/icxx/stat.hpp
@@ -26,6 +26,12 @@ namespace cldi
 	constexpr STAT TRUE = ::CLDI_TRUE;
 	constexpr STAT FALSE = ::CLDI_FALSE;
 
+	constexpr STAT CMPE = ::CLDI_CMPE;
+	constexpr STAT CMPL = ::CLDI_CMPL;
+	constexpr STAT CMPG = ::CLDI_CMPG;
+
+	constexpr STAT ELVL0 = ::CLDI_ELVL0;
+
 	constexpr STAT EUNKNOWN = ::CLDI_EUNKNOWN;
 
 	constexpr STAT ENO_IMPL = ::CLDI_ENO_IMPL;

--- a/stdlib/head-layer/include/cldi/head/setup/icxx/stat.hpp
+++ b/stdlib/head-layer/include/cldi/head/setup/icxx/stat.hpp
@@ -68,7 +68,12 @@ namespace cldi
 	constexpr CSTDLIB_ERRCONTEXT CSTDEC_VDPRINTF = ::CLDI_CSTDEC_VDPRINTF;
 	constexpr CSTDLIB_ERRCONTEXT CSTDEC_DPRINTF = ::CLDI_CSTDEC_DPRINTF;
 
-	inline STAT &ERRNO = CLDI_ERRNO;
+	using exc_t       = cldiexc_t;
+	using exception_t = cldiexc_t;
+	using error_t     = cldiexc_t;
+
+	inline exc_t &ERROR = CLDI_ERROR;
+	inline STAT  &ERRNO = CLDI_ERRNO;
 
 	/* Function for converting C++ standard library errors into CLDISTAT error
 	.  codes. */

--- a/stdlib/head-layer/include/cldi/head/setup/icxx/types.hpp
+++ b/stdlib/head-layer/include/cldi/head/setup/icxx/types.hpp
@@ -13,8 +13,12 @@
 namespace cldi
 {
 	using pid_t = ::cldipid_t;
+	using gid_t = ::cldigid_t;
+	using oid_t = ::cldioid_t;
 
-	inline pid_t (&GetCurrentPID)() = cldiGetCurrentPID;
+	inline pid_t (&GetCurrentPID)() = ::cldiGetCurrentPID;
+	inline gid_t (&GetCurrentGID)() = ::cldiGetCurrentGID;
+	inline oid_t (&GetCurrentOID)() = ::cldiGetCurrentOID;
 
 	using floatmax_t    = ::cldifpm_t;
 	using fpm_t         = ::cldifpm_t;

--- a/stdlib/head-layer/include/cldi/head/setup/stat.h
+++ b/stdlib/head-layer/include/cldi/head/setup/stat.h
@@ -29,6 +29,8 @@ typedef enum _CLDISTAT
 	CLDI_CMPLESS = CLDI_CMPL,
 	CLDI_CMPGREATER = CLDI_CMPG,
 
+	CLDI_ELVL0 = CLDI_CMPG,
+	
 	CLDI_EUNKNOWN,
 
 	CLDI_ENO_IMPL,
@@ -159,7 +161,7 @@ extern cldiexc_t CLDI_ERROR;
 	CLDI_ERROR.function=NULL;   \
 	CLDI_ERROR.ec=CLDI_SUCCESS;
 /* This macro is used for error catch statements. */
-#define CLDI_CATCH if(!cldiIsPermissible())
+#define CLDI_CATCH if(CLDI_STAT_NOTPERMISSIBLE(CLDI_ERROR.ec))
 
 /* Methods associated with CLDISTAT values: */
 
@@ -177,19 +179,23 @@ const char* cldiGetErrorDesc(CLDISTAT e);
 const char* cldiGetErrnoDesc();
 
 /* Check if an status value is a warning. */
-#define CLDI_STAT_ISWARNING(stat) (stat) < 0
+#define CLDI_STAT_ISWARNING(stat)  ((stat) < 0)
+#define CLDI_STAT_NOTWARNING(stat) ((stat) >= 0)
 bool cldiStatWarning(CLDISTAT e); // Registers the passed stat value to this shared object's errno and checks for warning
 bool cldiIsWarning(); // Checks the current shared object's errno value
 /* Check if an status value is an error. */
-#define CLDI_STAT_ISERROR(stat) (stat) > 0
+#define CLDI_STAT_ISERROR(stat)  ((stat) > 0)
+#define CLDI_STAT_NOTERROR(stat) ((stat) <= 0)
 bool cldiStatError(CLDISTAT e); // Registers the passed stat value to this shared object's errno and checks for error
 bool cldiIsError(); // Checks the current shared object's errno value
 /* Check if an status value is success. */
-#define CLDI_STAT_ISSUCCESS(stat) (stat) == 0
+#define CLDI_STAT_ISSUCCESS(stat)  ((stat) == 0)
+#define CLDI_STAT_NOTSUCCESS(stat) ((stat) != 0)
 bool cldiStatSuccess(CLDISTAT e); // Registers the passed stat value to this shared object's errno and checks for success
 bool cldiIsSuccess(); // Checks the current shared object's errno value
 /* Check if an status value is permissible. */
-#define CLDI_STAT_ISPERMISSIBLE(stat) (stat) <= 0 && (stat) <= CLDI_WPERMIT_LEVEL
+#define CLDI_STAT_ISPERMISSIBLE(stat)  ((stat) <= CLDI_ELVL0 && (stat) >= CLDI_WPERMIT_LEVEL)
+#define CLDI_STAT_NOTPERMISSIBLE(stat) ((stat) > CLDI_ELVL0 || (stat) < CLDI_WPERMIT_LEVEL)
 bool cldiStatPermissible(CLDISTAT e); // Registers the passed stat value to this shared object's errno and checks for warning
 bool cldiIsPermissible(); // Checks the current shared object's errno value
 

--- a/stdlib/head-layer/include/cldi/head/setup/stat.h
+++ b/stdlib/head-layer/include/cldi/head/setup/stat.h
@@ -22,7 +22,12 @@ typedef enum _CLDISTAT
 	CLDI_WLVL0   = CLDI_SUCCESS,
 	
 	CLDI_TRUE    = CLDI_SUCCESS,
+	CLDI_CMPE    = CLDI_SUCCESS,
 	CLDI_FALSE,
+	CLDI_CMPL    = CLDI_FALSE,
+	CLDI_CMPG,
+	CLDI_CMPLESS = CLDI_CMPL,
+	CLDI_CMPGREATER = CLDI_CMPG,
 
 	CLDI_EUNKNOWN,
 
@@ -68,8 +73,129 @@ typedef enum _CLDICSTDEC
 	CLDI_CSTDEC_DPRINTF   = CLDI_CSTDEC_PRINTF,
 } CLDI_CSTDLIB_ERRCONTEXT;
 
+/* Globally-Defined String Constants */
+extern const char *const CLDI_ERRNAME_WDEFRAG_RECOMMENDED;
+extern const char *const CLDI_ERRNAME_WLVL3;
+extern const char *const CLDI_ERRNAME_WLVL2;
+extern const char *const CLDI_ERRNAME_WLVL1;
+extern const char *const CLDI_ERRNAME_SUCCESS;
+extern const char *const CLDI_ERRNAME_WLVL0;
+extern const char *const CLDI_ERRNAME_TRUE;
+extern const char *const CLDI_ERRNAME_CMPE;
+extern const char *const CLDI_ERRNAME_FALSE;
+extern const char *const CLDI_ERRNAME_CMPL;
+extern const char *const CLDI_ERRNAME_CMPG;
+extern const char *const CLDI_ERRNAME_EUNKNOWN;
+extern const char *const CLDI_ERRNAME_ENO_IMPL;
+extern const char *const CLDI_ERRNAME_EOUT_OF_MEMORY;
+extern const char *const CLDI_ERRNAME_EDEFRAG_REQUIRED;
+extern const char *const CLDI_ERRNAME_ETOO_FEW_ARGS;
+extern const char *const CLDI_ERRNAME_EOVERFLOW;
+extern const char *const CLDI_ERRNAME_EOVERFLOW_ARG;
+extern const char *const CLDI_ERRNAME_EOVERFLOW_ATTR;
+extern const char *const CLDI_ERRNAME_ENULL_ATTR;
+extern const char *const CLDI_ERRNAME_ENULL_ARG;
+extern const char *const CLDI_ERRNAME_ENULL_SELF;
+extern const char *const CLDI_ERRNAME_EINVALID_ATTR;
+extern const char *const CLDI_ERRNAME_EINVALID_ARG;
+extern const char *const CLDI_ERRNAME_EINVALID_SELF;
+extern const char *const CLDI_ERRNAME_ENO_ACCESS;
+extern const char *const CLDI_ERRNAME_ENOT_READABLE;
+extern const char *const CLDI_ERRNAME_ENOT_WRITABLE;
+extern const char *const CLDI_ERRNAME_ENOT_EXECUTABLE;
+extern const char *const CLDI_ERRNAME_ENONEXISTENT;
+extern const char *const CLDI_ERRNAME_EINCOMPATIBLE_TYPE;
+extern const char *const CLDI_ERRDESC_WDEFRAG_RECOMMENDED;
+extern const char *const CLDI_ERRDESC_WLVL3;
+extern const char *const CLDI_ERRDESC_WLVL2;
+extern const char *const CLDI_ERRDESC_WLVL1;
+extern const char *const CLDI_ERRDESC_SUCCESS;
+extern const char *const CLDI_ERRDESC_WLVL0;
+extern const char *const CLDI_ERRDESC_TRUE;
+extern const char *const CLDI_ERRDESC_CMPE;
+extern const char *const CLDI_ERRDESC_FALSE;
+extern const char *const CLDI_ERRDESC_CMPL;
+extern const char *const CLDI_ERRDESC_CMPG;
+extern const char *const CLDI_ERRDESC_EUNKNOWN;
+extern const char *const CLDI_ERRDESC_ENO_IMPL;
+extern const char *const CLDI_ERRDESC_EOUT_OF_MEMORY;
+extern const char *const CLDI_ERRDESC_EDEFRAG_REQUIRED;
+extern const char *const CLDI_ERRDESC_ETOO_FEW_ARGS;
+extern const char *const CLDI_ERRDESC_EOVERFLOW;
+extern const char *const CLDI_ERRDESC_EOVERFLOW_ARG;
+extern const char *const CLDI_ERRDESC_EOVERFLOW_ATTR;
+extern const char *const CLDI_ERRDESC_ENULL_ATTR;
+extern const char *const CLDI_ERRDESC_ENULL_ARG;
+extern const char *const CLDI_ERRDESC_ENULL_SELF;
+extern const char *const CLDI_ERRDESC_EINVALID_ATTR;
+extern const char *const CLDI_ERRDESC_EINVALID_ARG;
+extern const char *const CLDI_ERRDESC_EINVALID_SELF;
+extern const char *const CLDI_ERRDESC_ENO_ACCESS;
+extern const char *const CLDI_ERRDESC_ENOT_READABLE;
+extern const char *const CLDI_ERRDESC_ENOT_WRITABLE;
+extern const char *const CLDI_ERRDESC_ENOT_EXECUTABLE;
+extern const char *const CLDI_ERRDESC_ENONEXISTENT;
+extern const char *const CLDI_ERRDESC_EINCOMPATIBLE_TYPE;
+
+/* Exception type */
+typedef struct _CLDIEXCEPTION
+{
+	const char *exc_name, *exc_desc;
+	void       *function;
+	CLDISTAT    ec; // ec = "error code"
+
+#if defined(__cplusplus) && C_ONLY_MODE == false
+
+	/* Create an error using just an error code. */
+	_CLDIEXCEPTION(CLDISTAT ec);
+	/* Create an error using an error code and a description (default mode). */
+	_CLDIEXCEPTION(CLDISTAT ec, const char *desc);
+	/* Create an error using an error code, name, and description. */
+	_CLDIEXCEPTION(CLDISTAT ec, const char *name, const char *desc);
+	/* Create an error using an error code, specified function address (the function
+	.  that was running when the error occurred), and description. */
+	_CLDIEXCEPTION(CLDISTAT ec, void *function, const char *desc);
+	/* Create an error using an error code, specified function address (the function
+	.  that was running when the error occurred), name, and description. */
+	_CLDIEXCEPTION(CLDISTAT ec, void *function, const char *name, const char *desc);
+
+	/* Throw an error using just an error code. */
+	static cldiexc_t* Throw(CLDISTAT ec);
+	/* Throw an error using an error code and a description (default mode). */
+	static cldiexc_t* Throw(CLDISTAT ec, const char *desc);
+	/* Throw an error using an error code, name, and description. */
+	static cldiexc_t* Throw(CLDISTAT ec, const char *name, const char *desc);
+	/* Throw an error using an error code, specified function address (the function
+	.  that was running when the error occurred), and description. */
+	static cldiexc_t* Throw(CLDISTAT ec, void *function, const char *desc);
+	/* Throw an error using an error code, specified function address (the function
+	.  that was running when the error occurred), name, and description. */
+	static cldiexc_t* Throw(CLDISTAT ec, void *function, const char *name, const char *desc);
+	/* Throw the current error. */
+	cldiexc_t Throw() const;
+
+	CLDISTAT    GetErrno();
+	void*       GetFunction();
+	const char* GetName();
+	const char* GetDesc();
+	bool        SpecifiesFunction();
+
+	/* Check if an exception is a warning. */
+	bool IsWarning();
+	/* Check if an exception is an error. */
+	bool IsError();
+	/* Check if an exception is success. */
+	bool IsSuccess();
+	/* Check if an exception is permissible. */
+	bool IsPermissible();
+
+#endif
+} cldiexception_t, cldiexc_t, cldierror_t;
 /* This is a global variable for passing errors while keeping return type. */
-extern CLDISTAT CLDI_ERRNO;
+extern cldiexc_t CLDI_ERROR;
+// This macro is defined as a QoD feature, as well as a backwards-compatibility
+// feature for code written before the cldiexception_t type was committed.
+#define CLDI_ERRNO (CLDI_ERROR.ec)
 
 /* Methods associated with CLDISTAT values: */
 
@@ -98,6 +224,51 @@ bool cldiIsSuccess(); // Checks the current shared object's errno value
 #define CLDI_STAT_ISPERMISSIBLE(stat) (stat) <= 0 && (stat) <= CLDI_WPERMIT_LEVEL
 bool cldiStatPermissible(CLDISTAT e); // Registers the passed stat value to this shared object's errno and checks for warning
 bool cldiIsPermissible(); // Checks the current shared object's errno value
+
+/* Methods associated with cldiexc_t objects: */
+
+/* Create an error using just an error code. */
+cldiexc_t cldierrec(CLDISTAT ec);
+/* Create an error using an error code and a description (default mode). */
+cldiexc_t cldierr(CLDISTAT ec, const char *desc);
+/* Create an error using an error code, name, and description. */
+cldiexc_t cldinerr(CLDISTAT ec, const char *name, const char *desc);
+/* Create an error using an error code, specified function address (the function
+.  that was running when the error occurred), and description. */
+cldiexc_t cldierrf(CLDISTAT ec, void *function, const char *desc);
+/* Create an error using an error code, specified function address (the function
+.  that was running when the error occurred), name, and description. */
+cldiexc_t cldinerrf(CLDISTAT ec, void *function, const char *name, const char *desc);
+
+/* Throw an error using just an error code. */
+cldiexc_t* cldithrowec(CLDISTAT ec);
+/* Throw an error using an error code and a description (default mode). */
+cldiexc_t* cldithrowd(CLDISTAT ec, const char *desc);
+/* Throw an error using an error code, name, and description. */
+cldiexc_t* cldinthrow(CLDISTAT ec, const char *name, const char *desc);
+/* Throw an error using an error code, specified function address (the function
+.  that was running when the error occurred), and description. */
+cldiexc_t* cldithrowf(CLDISTAT ec, void *function, const char *desc);
+/* Throw an error using an error code, specified function address (the function
+.  that was running when the error occurred), name, and description. */
+cldiexc_t* cldinthrowf(CLDISTAT ec, void *function, const char *name, const char *desc);
+/* Throw an exception object globally on the current thread. */
+cldiexc_t* cldithrow(cldiexc_t *self);
+
+CLDISTAT    cldiExcGetErrno(cldiexc_t *self);
+void*       cldiExcGetFunction(cldiexc_t *self);
+const char* cldiExcGetName(cldiexc_t *self);
+const char* cldiExcGetDesc(cldiexc_t *self);
+bool        cldiExcSpecifiesFunction(cldiexc_t *self);
+
+/* Check if an exception is a warning. */
+bool cldiExcIsWarning(cldiexc_t *self);
+/* Check if an exception is an error. */
+bool cldiExcIsError(cldiexc_t *self);
+/* Check if an exception is success. */
+bool cldiExcIsSuccess(cldiexc_t *self);
+/* Check if an exception is permissible. */
+bool cldiExcIsPermissible(cldiexc_t *self);
 
 #ifdef __cplusplus
 }

--- a/stdlib/head-layer/include/cldi/head/setup/stat.h
+++ b/stdlib/head-layer/include/cldi/head/setup/stat.h
@@ -223,10 +223,18 @@ cldiexc_t* cldinthrowf(CLDISTAT ec, void *function, const char *name, const char
 /* Throw an exception object globally on the current thread. */
 cldiexc_t* cldithrow(cldiexc_t *self);
 
+/* Add a traceback message to the current thrown error. */
+void       cldiAddTraceback(void *function, const char *desc);
+
+/* Get the error code of an exception. */
 CLDISTAT    cldiExcGetErrno(cldiexc_t *self);
+/* Get the specified calling function from an exception. */
 void*       cldiExcGetFunction(cldiexc_t *self);
+/* Get the name of an exception. */
 const char* cldiExcGetName(cldiexc_t *self);
+/* Get the description of an exception. */
 const char* cldiExcGetDesc(cldiexc_t *self);
+/* Check the exception for a specified calling function. */
 bool        cldiExcSpecifiesFunction(cldiexc_t *self);
 
 /* Check if an exception is a warning. */

--- a/stdlib/head-layer/include/cldi/head/setup/stat.h
+++ b/stdlib/head-layer/include/cldi/head/setup/stat.h
@@ -162,6 +162,19 @@ extern cldiexc_t CLDI_ERROR;
 	CLDI_ERROR.ec=CLDI_SUCCESS;
 /* This macro is used for error catch statements. */
 #define CLDI_CATCH if(CLDI_STAT_NOTPERMISSIBLE(CLDI_ERROR.ec))
+#if defined(__cldic)
+#	define CLDITHROWS   throws()
+#	define CLDITHROWEX  throws
+#	define CLDINOEXCEPT noexcept
+#elif CLDI_C_ONLY == false
+#	define CLDITHROWS       noexcept(false)
+#	define CLDITHROWEX(...) noexcept(false)
+#	define CLDINOEXCEPT     noexcept
+#else
+#	define CLDITHROWS
+#	define CLDITHROWEX(...)
+#	define CLDINOEXCEPT
+#endif
 
 /* Methods associated with CLDISTAT values: */
 

--- a/stdlib/head-layer/include/cldi/head/setup/types.h
+++ b/stdlib/head-layer/include/cldi/head/setup/types.h
@@ -9,7 +9,7 @@
 #ifdef __cplusplus
 extern "C" {
 #endif
-/* Process ID type */
+/* Process ID and Group ID type */
 #if CLDI_PLATFORM_UNIXLIKE == true
 typedef pid_t cldipid_t;
 #elif CLDI_PLATFORM == CLDI_WINDOWS
@@ -17,8 +17,21 @@ typedef DWORD cldipid_t;
 #else
 typedef uint32_t cldipid_t;
 #endif
+typedef int cldigid_t;
+#define CLDI_GID_ISINVALID(gid) ((gid) < 0)
+#define CLDI_GID_NULL    -1
+#define CLDI_DEFAULT_GID 0
+
+/* Ownership ID type */
+typedef struct _CLDIOID
+{
+	cldipid_t owner;
+	cldigid_t group;
+} cldioid_t, cldiownerid_t;
 
 cldipid_t cldiGetCurrentPID();
+cldigid_t cldiGetCurrentGID();
+cldioid_t cldiGetCurrentOID();
 
 
 /* Maximum-precision floating point type: */

--- a/stdlib/head-layer/include/cldi/head/setup/types.h
+++ b/stdlib/head-layer/include/cldi/head/setup/types.h
@@ -4,11 +4,12 @@
 
 #include "includes.h"
 
-
-
 #ifdef __cplusplus
 extern "C" {
 #endif
+
+
+
 /* Process ID and Group ID type */
 #if CLDI_PLATFORM_UNIXLIKE == true
 typedef pid_t cldipid_t;

--- a/stdlib/head-layer/lib/c/setup.stat.c
+++ b/stdlib/head-layer/lib/c/setup.stat.c
@@ -6,8 +6,77 @@
 
 
 
-CLDISTAT CLDI_ERRNO = CLDI_SUCCESS;
+const char *const CLDI_NO_ERRNAME = "<anonymous>";
+const char *const CLDI_ERRNAME_WDEFRAG_RECOMMENDED = "WDEFRAG_RECOMMENDED";
+const char *const CLDI_ERRNAME_WLVL3 = "WLVL3";
+const char *const CLDI_ERRNAME_WLVL2 = "WLVL2";
+const char *const CLDI_ERRNAME_WLVL1 = "WLVL1";
+const char *const CLDI_ERRNAME_SUCCESS = "SUCCESS";
+const char *const CLDI_ERRNAME_WLVL0 = "WLVL0";
+const char *const CLDI_ERRNAME_TRUE = "TRUE";
+const char *const CLDI_ERRNAME_CMPE = "CMPE";
+const char *const CLDI_ERRNAME_FALSE = "FALSE";
+const char *const CLDI_ERRNAME_CMPL = "CMPL";
+const char *const CLDI_ERRNAME_CMPG = "CMPG";
+const char *const CLDI_ERRNAME_EUNKNOWN = "EUNKNOWN";
+const char *const CLDI_ERRNAME_ENO_IMPL = "ENO_IMPL";
+const char *const CLDI_ERRNAME_EOUT_OF_MEMORY = "EOUT_OF_MEMORY";
+const char *const CLDI_ERRNAME_EDEFRAG_REQUIRED = "EDEFRAG_REQUIRED";
+const char *const CLDI_ERRNAME_ETOO_FEW_ARGS = "ETOO_FEW_ARGS";
+const char *const CLDI_ERRNAME_EOVERFLOW = "EOVERFLOW";
+const char *const CLDI_ERRNAME_EOVERFLOW_ARG = "EOVERFLOW_ARG";
+const char *const CLDI_ERRNAME_EOVERFLOW_ATTR = "EOVERFLOW_ATTR";
+const char *const CLDI_ERRNAME_ENULL_ATTR = "ENULL_ATTR";
+const char *const CLDI_ERRNAME_ENULL_ARG = "ENULL_ARG";
+const char *const CLDI_ERRNAME_ENULL_SELF = "ENULL_SELF";
+const char *const CLDI_ERRNAME_EINVALID_ATTR = "EINVALID_ATTR";
+const char *const CLDI_ERRNAME_EINVALID_ARG = "EINVALID_ARG";
+const char *const CLDI_ERRNAME_EINVALID_SELF = "EINVALID_SELF";
+const char *const CLDI_ERRNAME_ENO_ACCESS = "ENO_ACCESS";
+const char *const CLDI_ERRNAME_ENOT_READABLE = "ENOT_READABLE";
+const char *const CLDI_ERRNAME_ENOT_WRITABLE = "ENOT_WRITABLE";
+const char *const CLDI_ERRNAME_ENOT_EXECUTABLE = "ENOT_EXECUTABLE";
+const char *const CLDI_ERRNAME_ENONEXISTENT = "ENONEXISTENT";
+const char *const CLDI_ERRNAME_EINCOMPATIBLE_TYPE = "EINCOMPATIBLE_TYPE";
+const char *const CLDI_NO_ERRDESC = "No description provided.";
+const char *const CLDI_ERRDESC_WDEFRAG_RECOMMENDED = "Heap defragmentation is recommended.";
+const char *const CLDI_ERRDESC_WLVL3 = "<Warning-Level-3>";
+const char *const CLDI_ERRDESC_WLVL2 = "<Warning-Level-2>";
+const char *const CLDI_ERRDESC_WLVL1 = "<Warning-Level-1>";
+const char *const CLDI_ERRDESC_SUCCESS = "No error occurred.";
+const char *const CLDI_ERRDESC_WLVL0 = "<Warning-Level-0>";
+const char *const CLDI_ERRDESC_TRUE = "Status evaluates to true.";
+const char *const CLDI_ERRDESC_CMPE = "Comparison evaluates terms as equal.";
+const char *const CLDI_ERRDESC_FALSE = "Status evaluates to false.";
+const char *const CLDI_ERRDESC_CMPL = "Comparison evaluates term as less.";
+const char *const CLDI_ERRDESC_CMPG = "Comparison evaluates term as greater.";
+const char *const CLDI_ERRDESC_EUNKNOWN = "Unknown error occurred.";
+const char *const CLDI_ERRDESC_ENO_IMPL = "No implementation provided for this operation.";
+const char *const CLDI_ERRDESC_EOUT_OF_MEMORY = "System or application ran out of usable memory.";
+const char *const CLDI_ERRDESC_EDEFRAG_REQUIRED = "Heap defragmentation is required.";
+const char *const CLDI_ERRDESC_ETOO_FEW_ARGS = "Not enough arguments were given for this operation";
+const char *const CLDI_ERRDESC_EOVERFLOW = "Operation produced an overflowing result (out of bounds or undefined).";
+const char *const CLDI_ERRDESC_EOVERFLOW_ARG = "Argument is an overflowed value (out of bounds or undefined).";
+const char *const CLDI_ERRDESC_EOVERFLOW_ATTR = "An attribute of self is an overflowed value (out of bounds or undefined).";
+const char *const CLDI_ERRDESC_ENULL_ATTR = "A required attribute of self is null.";
+const char *const CLDI_ERRDESC_ENULL_ARG = "A non-optional argument was given as null.";
+const char *const CLDI_ERRDESC_ENULL_SELF = "Self is constructed with null data, this operation cannot continue.";
+const char *const CLDI_ERRDESC_EINVALID_ATTR;
+const char *const CLDI_ERRDESC_EINVALID_ARG = "An argument was passed as an invalid value.";
+const char *const CLDI_ERRDESC_EINVALID_SELF = "Self is constructed with invalid data, this operation cannot continue.";
+const char *const CLDI_ERRDESC_ENO_ACCESS = "Access is denied for this operation.";
+const char *const CLDI_ERRDESC_ENOT_READABLE = "Data is not readable; Attempted read of non-readable data.";
+const char *const CLDI_ERRDESC_ENOT_WRITABLE = "Data is not writable; Attempted write on non-writable data. ";
+const char *const CLDI_ERRDESC_ENOT_EXECUTABLE = "Data is not executable; Attempted call on non-executable data.";
+const char *const CLDI_ERRDESC_ENONEXISTENT = "Attempted to reference a nonexistent entry.";
+const char *const CLDI_ERRDESC_EINCOMPATIBLE_TYPE = "Attempted conflation of incompatible or inconvertable data types.";
 
+cldiexc_t CLDI_ERROR = {
+	.exc_name = "SUCCESS",
+	.exc_desc = "No error occurred.",
+	.function = NULL,
+	.ec       = CLDI_SUCCESS
+};
 
 const char* cldiGetErrorName(CLDISTAT e)
 {
@@ -90,6 +159,192 @@ bool cldiStatPermissible(CLDISTAT e)
 bool cldiIsPermissible()
 {
 	return CLDI_STAT_ISPERMISSIBLE(CLDI_ERRNO);
+}
+
+cldiexc_t cldierrec(CLDISTAT __ec)
+{
+	return (cldiexc_t) {
+		.exc_name=cldiGetErrorName(__ec),
+		.exc_desc=CLDI_NO_ERRDESC,
+		.function=NULL,
+		.ec=__ec
+	};
+}
+cldiexc_t cldierr(CLDISTAT __ec, const char *desc)
+{
+	return (cldiexc_t) {
+		.exc_name=cldiGetErrorName(__ec),
+		.exc_desc=desc,
+		.function=NULL,
+		.ec=__ec
+	};
+}
+cldiexc_t cldinerr(CLDISTAT __ec, const char *name, const char *desc)
+{
+	return (cldiexc_t) {
+		.exc_name=name,
+		.exc_desc=desc,
+		.function=NULL,
+		.ec=__ec
+	};
+}
+cldiexc_t cldierrf(CLDISTAT __ec, void *func, const char *desc)
+{
+	return (cldiexc_t) {
+		.exc_name=cldiGetError(__ec),
+		.exc_desc=desc,
+		.function=func,
+		.ec=__ec
+	};
+}
+cldiexc_t cldinerrf(CLDISTAT __ec, void *func, const char *name, const char *desc)
+{
+	return (cldiexc_t) {
+		.exc_name=name,
+		.exc_desc=desc,
+		.function=func,
+		.ec=__ec
+	};
+}
+
+// Throws an exception without copying it to CLDI_ERROR, this is used internally,
+// and for this file only.
+void _cldithrowexc(cldiexc_t *exc)
+{
+	// THIS CODE IS DUE TO CHANGE ONCE THREAD-SAFE IO FUNCTIONS ARE ADDED
+
+	if (exc != NULL) {
+		const CLDISTAT ec = exc->ec;
+		if (!(CLDI_STAT_ISSUCCESS(ec))) {
+			const char *excname = (exc->exc_name == NULL)? cldiGetErrorName(ec) : exc->exc_name;
+			const char *excdesc = (exc->exc_desc == NULL)? cldiGetErrorDesc(ec) : exc->exc_desc;
+
+			if (exc->function != NULL)
+				fprintf(stderr, "Encountered an exception in function %p ", exc->function);
+			else
+				fprintf(stderr, "Encountered an exception ");
+			// continue error message with error name, desc, and code
+			fprintf(stderr, " with code %d (%s):\n\t%s\n", ec, excname, excdesc);
+		}
+	} else {
+		fprintf(stderr, "Attempt was made to throw nullptr exception...\n");
+	}
+}
+cldiexc_t* cldithrowec(CLDISTAT __ec)
+{
+	cldiexc_t e = cldierrec(__ec);
+
+	cldithrow(&e);
+
+	return &CLDI_ERROR;
+}
+cldiexc_t* cldithrowd(CLDISTAT __ec, const char *desc)
+{
+	cldiexc_t e = cldierr(__ec, desc);
+
+	cldithrow(&e);
+
+	return &CLDI_ERROR;
+}
+cldiexc_t* cldinthrow(CLDISTAT __ec, const char *name, const char *desc)
+{
+	cldiexc_t e = cldinerr(__ec, name, desc);
+
+	cldithrow(&e);
+
+	return &CLDI_ERROR;
+}
+cldiexc_t* cldithrowf(CLDISTAT __ec, void *func, const char *desc)
+{
+	cldiexc_t e = cldierrf(__ec, func, desc);
+
+	cldithrow(&e);
+
+	return &CLDI_ERROR;
+}
+cldiexc_t* cldinthrowf(CLDISTAT __ec, void *func, const char *name, const char *desc)
+{
+	cldiexc_t e = cldinerrf(__ec, func, name, desc);
+
+	cldithrow(&e);
+
+	return &CLDI_ERROR;
+}
+cldiexc_t* cldithrow(cldiexc_t *self)
+{
+	// set the current error to self
+	CLDI_ERROR.exc_name = self->exc_name;
+	CLDI_ERROR.exc_desc = self->exc_desc;
+	CLDI_ERROR.function = self->function;
+	CLDI_ERROR.ec       = self->ec;
+
+	_cldithrowexc(self);
+
+	return &CLDI_ERROR;
+}
+
+CLDISTAT    cldiExcGetErrno(cldiexc_t *self)
+{
+	if (self == NULL)
+		return CLDI_ENULL_ARG;
+	else
+		return self->ec;
+}
+void*       cldiExcGetFunction(cldiexc_t *self)
+{
+	if (self == NULL)
+		return CLDI_ENULL_ARG;
+	else
+		return self->function;
+}
+const char* cldiExcGetName(cldiexc_t *self)
+{
+	if (self == NULL)
+		return CLDI_ENULL_ARG;
+	else
+		return self->exc_name;
+}
+const char* cldiExcGetDesc(cldiexc_t *self)
+{
+	if (self == NULL)
+		return CLDI_ENULL_ARG;
+	else
+		return self->exc_desc;
+}
+bool        cldiExcSpecifiesFunction(cldiexc_t *self)
+{
+	if (self == NULL)
+		return false;
+	else
+		return self->function != NULL;
+}
+bool cldiExcIsWarning(cldiexc_t *self)
+{
+	if (self == NULL)
+		return false;
+	else
+		return CLDI_STAT_ISWARNING(self->ec);
+}
+bool cldiExcIsError(cldiexc_t *self)
+{
+	if (self == NULL)
+		return false;
+	else
+		return CLDI_STAT_ISERROR(self->ec);
+}
+bool cldiExcIsSuccess(cldiexc_t *self)
+{
+	if (self == NULL)
+		return false;
+	else
+		return CLDI_STAT_ISSUCCESS(self->ec);
+}
+bool cldiExcIsPermissible(cldiexc_t *self)
+{
+	if (self == NULL)
+		return false;
+	else
+		return CLDI_STAT_ISPERMISSIBLE(self->ec);
 }
 
 


### PR DESCRIPTION
Update head/memory.h and head/icxx/memory.hpp with operative functions for creating, destroying and managing cldimemref and cldiheap_t objects (7dcb68de39070c96d71c9d3a9bfa9e04010cfabc).
devtest-memory->devtest-iter